### PR TITLE
fix: use machine to recognize 32 or 64 bit binary

### DIFF
--- a/DotNet/SigFlip/SigFlip/PE.cs
+++ b/DotNet/SigFlip/SigFlip/PE.cs
@@ -30,18 +30,18 @@ namespace SigFlip
                 UInt32 ntHeadersSignature = reader.ReadUInt32();
                 fileHeader = Utils.FromBinaryReader<IMAGE_FILE_HEADER>(reader);
 
-                if (Utils.Is32Bit(this.fileHeader.Characteristics))
-                {
-                    optionalHeader32 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER32>(reader);
-                    stream.Seek(optionalHeader32.CertificateTable.VirtualAddress, SeekOrigin.Begin);
-                    winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
-                }
-                else
-                {
-                    optionalHeader64 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER64>(reader);
-                    stream.Seek(optionalHeader64.CertificateTable.VirtualAddress, SeekOrigin.Begin);
-                    winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
-                }
+                if (fileHeader.Machine == 0x14C) // Intel 386 (32-bit)
+				{
+					optionalHeader32 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER32>(reader);
+					stream.Seek(optionalHeader32.CertificateTable.VirtualAddress, SeekOrigin.Begin);
+					winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
+				}
+				else
+				{
+					optionalHeader64 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER64>(reader);
+					stream.Seek(optionalHeader64.CertificateTable.VirtualAddress, SeekOrigin.Begin);
+					winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
+				}
 
                
 

--- a/DotNet/SigFlip/SigFlip/PE.cs
+++ b/DotNet/SigFlip/SigFlip/PE.cs
@@ -31,17 +31,17 @@ namespace SigFlip
                 fileHeader = Utils.FromBinaryReader<IMAGE_FILE_HEADER>(reader);
 
                 if (fileHeader.Machine == 0x14C) // Intel 386 (32-bit)
-				{
-					optionalHeader32 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER32>(reader);
-					stream.Seek(optionalHeader32.CertificateTable.VirtualAddress, SeekOrigin.Begin);
-					winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
-				}
-				else
-				{
-					optionalHeader64 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER64>(reader);
-					stream.Seek(optionalHeader64.CertificateTable.VirtualAddress, SeekOrigin.Begin);
-					winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
-				}
+               {
+                    optionalHeader32 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER32>(reader);
+                    stream.Seek(optionalHeader32.CertificateTable.VirtualAddress, SeekOrigin.Begin);
+                    winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
+                }
+                else
+                {
+                    optionalHeader64 = Utils.FromBinaryReader<IMAGE_OPTIONAL_HEADER64>(reader);
+                    stream.Seek(optionalHeader64.CertificateTable.VirtualAddress, SeekOrigin.Begin);
+                    winCert = Utils.FromBinaryReader<WIN_CERTIFICATE>(reader);
+                }
 
                
 

--- a/DotNet/SigFlip/SigFlip/Program.cs
+++ b/DotNet/SigFlip/SigFlip/Program.cs
@@ -118,18 +118,18 @@ namespace SigFlip
             //Update dwLength and Cert Table Entry Size (OPT Header Data Dir)
             _pe.winCert.dwLength += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
             if (_FEHeaderMachine == 0x10B) // Intel 386 (32-bit)
-			{
-				_pe.optionalHeader32.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
-				_CertificateTable = _pe.optionalHeader32.CertificateTable;
-				_AttrCertTableRVA = _pe.optionalHeader32.CertificateTable.VirtualAddress;
-			}
-			else
-			{
-				_pe.optionalHeader64.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
-				_CertificateTable = _pe.optionalHeader64.CertificateTable;
-				_AttrCertTableRVA = _pe.optionalHeader64.CertificateTable.VirtualAddress;
-				CERT_TABLE_RVA_OFFSET += 16;
-			}
+            {
+                _pe.optionalHeader32.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
+                _CertificateTable = _pe.optionalHeader32.CertificateTable;
+                _AttrCertTableRVA = _pe.optionalHeader32.CertificateTable.VirtualAddress;
+            }
+            else
+            {
+                _pe.optionalHeader64.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
+                _CertificateTable = _pe.optionalHeader64.CertificateTable;
+                _AttrCertTableRVA = _pe.optionalHeader64.CertificateTable.VirtualAddress;
+                CERT_TABLE_RVA_OFFSET += 16;
+            }
 
 
             Console.WriteLine("[+]:Updating OPT Header fields/entries");

--- a/DotNet/SigFlip/SigFlip/Program.cs
+++ b/DotNet/SigFlip/SigFlip/Program.cs
@@ -95,7 +95,7 @@ namespace SigFlip
             byte[] _data = _mode == MODE.BIT_FLIP ? Encoding.ASCII.GetBytes(Utils.GenRandomBytes(RANDOM_BYTES_SIZE)) : Utils.Encrypt(Utils.Read(_dataPath),_encKey);
             Utils.WriteFile(@"C:\users\public\encrypted-shellcode.bin", _data);
             //Local variables
-            ushort _FEHeaderCharacteristics = _pe.fileHeader.Characteristics;
+            ushort _FEHeaderMachine = _pe.fileHeader.Machine;
             IMAGE_DATA_DIRECTORY _CertificateTable;
             uint _AttrCertTableRVA = 0;
 
@@ -117,19 +117,19 @@ namespace SigFlip
 
             //Update dwLength and Cert Table Entry Size (OPT Header Data Dir)
             _pe.winCert.dwLength += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
-            if (Utils.Is32Bit(_FEHeaderCharacteristics))
-            {
-                _pe.optionalHeader32.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
-                _CertificateTable = _pe.optionalHeader32.CertificateTable;
-                _AttrCertTableRVA = _pe.optionalHeader32.CertificateTable.VirtualAddress;
-            }
-            else
-            {
-                _pe.optionalHeader64.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
-                _CertificateTable = _pe.optionalHeader64.CertificateTable;
-                _AttrCertTableRVA = _pe.optionalHeader64.CertificateTable.VirtualAddress;
-                CERT_TABLE_RVA_OFFSET += 16;
-            }
+            if (_FEHeaderMachine == 0x10B) // Intel 386 (32-bit)
+			{
+				_pe.optionalHeader32.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
+				_CertificateTable = _pe.optionalHeader32.CertificateTable;
+				_AttrCertTableRVA = _pe.optionalHeader32.CertificateTable.VirtualAddress;
+			}
+			else
+			{
+				_pe.optionalHeader64.CertificateTable.Size += Convert.ToUInt32(_data.Length + _paddingLen + _tagLen);
+				_CertificateTable = _pe.optionalHeader64.CertificateTable;
+				_AttrCertTableRVA = _pe.optionalHeader64.CertificateTable.VirtualAddress;
+				CERT_TABLE_RVA_OFFSET += 16;
+			}
 
 
             Console.WriteLine("[+]:Updating OPT Header fields/entries");


### PR DESCRIPTION
Modify the logic to determine whether the file is a 32-bit or 64-bit architecture. Some files have a file header characteristic that might make us think they are 32-bit, but they actually need to be parsed using a 64-bit structure. I've modified it this way to better address this issue.

You can use the files in demo.zip to reproduce the issue where a 64-bit file is incorrectly identified as 32-bit.
[demo.zip](https://github.com/user-attachments/files/17917283/demo.zip)
